### PR TITLE
Follow redirect when testing URL, and fix url testing.

### DIFF
--- a/intersphinx_registry/registry.json
+++ b/intersphinx_registry/registry.json
@@ -27,8 +27,8 @@
   "distlib": ["https://distlib.readthedocs.io/en/latest/", null],
   "distributed": ["https://distributed.dask.org/en/stable/", null],
   "django": [
-    "https://docs.djangoproject.com/en/2.2/",
-    "https://docs.djangoproject.com/en/2.2/_objects/"
+    "https://docs.djangoproject.com/en/stable/",
+    "https://docs.djangoproject.com/en/stable/_objects/"
   ],
   "dlpack": ["https://dmlc.github.io/dlpack/latest/", null],
   "flax": ["https://flax.readthedocs.io/en/latest/", null],
@@ -147,7 +147,10 @@
   "sparse": ["https://sparse.pydata.org/en/latest/", null],
   "sphinx": ["https://www.sphinx-doc.org/en/master/", null],
   "sphinx-gallery": ["https://sphinx-gallery.github.io/stable/", null],
-  "sphinx_automodapi": ["https://sphinx-automodapi.readthedocs.io/en/stable/", null],
+  "sphinx_automodapi": [
+    "https://sphinx-automodapi.readthedocs.io/en/stable/",
+    null
+  ],
   "sqlalchemy": ["https://docs.sqlalchemy.org/en/latest/", null],
   "statsmodels": ["https://www.statsmodels.org/stable/", null],
   "sympy": ["https://docs.sympy.org/latest/", null],

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -9,13 +9,19 @@ keys = set(MAPPING.keys())
 @pytest.mark.parametrize("key", list(sorted(keys - {"jinja"})))
 def test_format(key: str):
     assert isinstance(key, str)
-    for v in MAPPING[key]:
-        if v is None:
-            continue
-        assert v.startswith("https://"), v
-        assert v.endswith("/"), v
-        assert "readthedocs.org" not in v
-        requests.head(v + "objects.inv").raise_for_status()
+    url, obj = MAPPING[key]
+    assert url.startswith("https://"), url
+    assert url.endswith("/"), url
+    assert "readthedocs.org" not in url, "should be readthedocs.io not org"
+
+    if obj is None:
+        requests.head(url + "objects.inv", allow_redirects=True).raise_for_status()
+    else:
+        assert obj.startswith("https://"), obj
+        assert obj.endswith("/"), obj
+        assert "readthedocs.org" not in obj
+        assert obj.startswith(url)
+        requests.head(obj, allow_redirects=True).raise_for_status()
 
 
 @pytest.mark.parametrize("key", list(sorted(keys)))


### PR DESCRIPTION
From my understanding of the intersphinx mapping the testing was incorrect.

Here I am a bit stricter by forcing the second parameter to be a full url (or None), in which case the second parameter must be a subpatch of the first one.

We also follow redirect (301) to make sure the final version exists, otherwise 301 does not raise for status.