### PR TITLE
Improve lookup with full url, and filter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,34 @@ intersphinx_mapping.update({
 
 You can use the following to lookup target/webpages of various packages.
 
+Call without arguments to get help:
+
 ```
-$ python -m intersphinx_registry.lookup ipython | grep whatsnew7
-    whatsnew700                              IPython 7.0.0                           : whatsnew/version7.html#whatsnew700
-    whatsnew710                              IPython 7.1.0                           : whatsnew/version7.html#whatsnew710
-    whatsnew720                              IPython 7.2.0                           : whatsnew/version7.html#whatsnew720
-    whatsnew730                              IPython 7.3.0                           : whatsnew/version7.html#whatsnew730
-    whatsnew740                              IPython 7.4.0                           : whatsnew/version7.html#whatsnew740
-    whatsnew750                              IPython 7.5.0                           : whatsnew/version7.html#whatsnew750
-    whatsnew760                              IPython 7.6.0                           : whatsnew/version7.html#whatsnew760
+$ python -m intersphinx_registry.lookup
+
+    Usage: python -m intersphinx_registry.lookup <package>[,package] [search_term]
+
+    Example:
+
+    $ python -m intersphinx_registry.lookup numpy,scipy array
+    $ python -m intersphinx_registry.lookup ipython formatters.html
+
 ```
+
+You can search multiple packages as once.
+
+```
+$ python -m intersphinx_registry.lookup numpy,scipy Universal
+std:label ufuncs                             NumPy 2.1    'Universal functions (ufunc)'                         https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs
+std:label ufuncs-basics                      NumPy 2.1    'Universal functions (ufunc) basics'                  https://numpy.org/doc/stable/user/basics.ufuncs.html#ufuncs-basics
+std:label ufuncs-internals                   NumPy 2.1    'Universal functions'                                 https://numpy.org/doc/stable/dev/internals.code-explanations.html#ufuncs-internals
+std:doc   reference/ufuncs                   NumPy 2.1    'Universal functions (ufunc)'                         https://numpy.org/doc/stable/reference/ufuncs.html
+std:doc   user/basics.ufuncs                 NumPy 2.1    'Universal functions (ufunc) basics'                  https://numpy.org/doc/stable/user/basics.ufuncs.html
+std:label non-uniform-random-number-sampling SciPy 1.14.1 'Universal Non-Uniform Random Number Sampling in SciPy' https://docs.scipy.org/doc/scipy/tutorial/stats/sampling.html#non-uniform-random-number-sampling
+std:doc   tutorial/stats/sampling            SciPy 1.14.1 'Universal Non-Uniform Random Number Sampling in SciPy' https://docs.scipy.org/doc/scipy/tutorial/stats/sampling.html
+```
+
+Warning, there is no cache, it downloads the inventory of each mentioned package every time.
 
 
 ## Why ?

--- a/intersphinx_registry/lookup.py
+++ b/intersphinx_registry/lookup.py
@@ -1,21 +1,75 @@
 import sys
 
 from intersphinx_registry import get_intersphinx_mapping
-import logging as _logging
-from sphinx.ext.intersphinx import inspect_main
 from urllib.parse import urljoin
 
-if len(sys.argv) != 2:
-    sys.exit("Usage: python -m intersphinx_registry.lookup <package>")
+from typing import Optional
 
-packages = set([sys.argv[1]])
+from sphinx.util.inventory import InventoryFile
+from io import BytesIO
+
+# filename = 'https://ipython.readthedocs.io/en/latest/'
+import requests
+
+if len(sys.argv) not in [2, 3]:
+    sys.exit(
+        """Usage: python -m intersphinx_registry.lookup <package>[,package] [search_term]
+
+        Example:
+
+        $ python -m intersphinx_registry.lookup numpy,scipy array
+        $ python -m intersphinx_registry.lookup ipython formatters.html
+
+        """
+    )
+
+packages = set(sys.argv[1].split(","))
+
+search_term: Optional[str]
+if len(sys.argv) == 3:
+    search_term = sys.argv[2]
+else:
+    search_term = None
 
 # there will be only one url
 urls = [
-    urljoin(u[0], (u[1] if u[1] else "objects.inv"))
+    (u[0], (u[1] if u[1] else "objects.inv"))
     for u in get_intersphinx_mapping(packages=packages).values()
 ]
 
+flattened = []
+for base_url, obj in urls:
 
-_logging.basicConfig()
-raise SystemExit(inspect_main(urls))
+    final_url = urljoin(base_url, obj)
+
+    resp = requests.get(final_url)
+
+    inv = InventoryFile.load(BytesIO(resp.content), base_url, urljoin)
+
+    for key, v in inv.items():
+        inv_entries = sorted(v.items())
+        for entry, (_proj, _ver, url_path, display_name) in inv_entries:
+            # display_name = display_name * (display_name != '-')
+            flattened.append((key, entry, _proj, _ver, display_name, url_path))
+
+filtered = []
+
+width = [len(x) for x in flattened[0]]
+
+for item in flattened:
+    key, entry, proj, version, display_name, url_path = item
+    if (
+        (search_term is None)
+        or (search_term in entry)
+        or (search_term in display_name)
+        or (search_term in url_path)
+    ):
+        filtered.append((key, entry, proj, version, display_name, url_path))
+        width = [max(w, len(x)) for w, x in zip(width, item)]
+
+
+for key, entry, proj, version, display_name, url_path in filtered:
+    w_key, w_entry, w_proj, w_version, w_di, w_url = width
+    print(
+        f"{key:<{w_key}}  {entry:<{w_entry}}  {proj:<{w_proj}}  {version:<{w_version}}  {display_name!r:<{w_di+2}}  {url_path}"
+    )


### PR DESCRIPTION
```
$ python -m intersphinx_registry.lookup numpy,scipy Universal
std:label ufuncs                             NumPy 2.1    'Universal functions (ufunc)'                         https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs
std:label ufuncs-basics                      NumPy 2.1    'Universal functions (ufunc) basics'                  https://numpy.org/doc/stable/user/basics.ufuncs.html#ufuncs-basics
std:label ufuncs-internals                   NumPy 2.1    'Universal functions'                                 https://numpy.org/doc/stable/dev/internals.code-explanations.html#ufuncs-internals
std:doc   reference/ufuncs                   NumPy 2.1    'Universal functions (ufunc)'                         https://numpy.org/doc/stable/reference/ufuncs.html
std:doc   user/basics.ufuncs                 NumPy 2.1    'Universal functions (ufunc) basics'                  https://numpy.org/doc/stable/user/basics.ufuncs.html
std:label non-uniform-random-number-sampling SciPy 1.14.1 'Universal Non-Uniform Random Number Sampling in SciPy' https://docs.scipy.org/doc/scipy/tutorial/stats/sampling.html#non-uniform-random-number-sampling
std:doc   tutorial/stats/sampling            SciPy 1.14.1 'Universal Non-Uniform Random Number Sampling in SciPy' https://docs.scipy.org/doc/scipy/tutorial/stats/sampling.html
```



