### PR TITLE
Update inventory for SciTools-Cartopy

### DIFF
--- a/intersphinx_registry/registry.json
+++ b/intersphinx_registry/registry.json
@@ -12,7 +12,7 @@
   "boltons": ["https://boltons.readthedocs.io/en/latest/", null],
   "bottle": ["https://bottlepy.org/docs/dev/", null],
   "build": ["https://build.pypa.io/en/latest/", null],
-  "cartopy": ["https://scitools.org.uk/cartopy/docs/latest/", null],
+  "cartopy": ["https://cartopy.readthedocs.io/latest/", null],
   "cffi": ["https://cffi.readthedocs.io/en/latest/", null],
   "click": ["https://click.palletsprojects.com/", null],
   "cloudpathlib": ["https://cloudpathlib.drivendata.org/stable/", null],


### PR DESCRIPTION
https://scitools.org.uk/cartopy/docs/latest/objects.inv no longer exists; replace with https://cartopy.readthedocs.io/latest/.