### PR TITLE
TMP, FIX: use dev site for Scipy registry

### DIFF
--- a/intersphinx_registry/registry.json
+++ b/intersphinx_registry/registry.json
@@ -155,7 +155,7 @@
   "rtd": ["https://docs.readthedocs.io/en/stable/", null],
   "rtd-dev": ["https://dev.readthedocs.io/en/latest/", null],
   "scanpy": ["https://scanpy.readthedocs.io/en/stable/", null],
-  "scipy": ["https://docs.scipy.org/doc/scipy/", null],
+  "scipy": ["https://scipy.github.io/devdocs/", null],
   "scipy-lecture-notes": ["https://scipy-lectures.org/", null],
   "scriptconfig": ["https://scriptconfig.readthedocs.io/en/latest/", null],
   "seaborn": ["https://seaborn.pydata.org/", null],


### PR DESCRIPTION
Fixes #71 

Per this comment https://github.com/scipy/docs.scipy.org/issues/102#issue-3504455067 , using Scipy's developer site should still work for the registry and is not having the performance issues that the main site is having. I tested this out on another project ( https://github.com/mne-tools/mne-icalabel/pull/271 ) and it seems to work fine, where intersphinx failed to load the Scipy Inventory on the stable site.

If you'd prefer to wait and see if the Scipy folks address their website performance, then feel free to let this PR hang for a while.