### PR TITLE
Revert "TMP, FIX: use dev site for Scipy registry"

### DIFF
--- a/intersphinx_registry/registry.json
+++ b/intersphinx_registry/registry.json
@@ -155,7 +155,7 @@
   "rtd": ["https://docs.readthedocs.io/en/stable/", null],
   "rtd-dev": ["https://dev.readthedocs.io/en/latest/", null],
   "scanpy": ["https://scanpy.readthedocs.io/en/stable/", null],
-  "scipy": ["https://scipy.github.io/devdocs/", null],
+  "scipy": ["https://docs.scipy.org/doc/scipy/", null],
   "scipy-lecture-notes": ["https://scipy-lectures.org/", null],
   "scriptconfig": ["https://scriptconfig.readthedocs.io/en/latest/", null],
   "seaborn": ["https://seaborn.pydata.org/", null],


### PR DESCRIPTION
Reverts Quansight-Labs/intersphinx_registry#72

This is a temporary fix that should be reverted once the scipy website is back on track.