### PR TITLE
Point to `hyperspy` devdocs

### DIFF
--- a/intersphinx_registry/registry.json
+++ b/intersphinx_registry/registry.json
@@ -43,7 +43,7 @@
   "geopandas": ["https://geopandas.org/en/stable/", null],
   "h5py": ["https://docs.h5py.org/en/stable/", null],
   "hub": ["https://jupyterhub.readthedocs.io/en/latest/", null],
-  "hyperspy": ["https://hyperspy.org/hyperspy-doc/current/", null],
+  "hyperspy": ["https://hyperspy.org/hyperspy-doc/dev/", null],
   "imageio": ["https://imageio.readthedocs.io/en/stable/", null],
   "iminuit": ["https://iminuit.readthedocs.io/en/stable/", null],
   "importlib-resources": ["https://importlib-resources.readthedocs.io/en/latest/", null],


### PR DESCRIPTION
...for now, see #74. Not sure why https://hyperspy.org/hyperspy-doc/current/objects.inv is a 404 but https://hyperspy.org/hyperspy-doc/dev/objects.inv is not.