### PR TITLE
Add reverse-lookup, rev-search commands and inventory caching

### DIFF
--- a/intersphinx_registry/__main__.py
+++ b/intersphinx_registry/__main__.py
@@ -1,0 +1,4 @@
+from intersphinx_registry.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/intersphinx_registry/cli.py
+++ b/intersphinx_registry/cli.py
@@ -1,11 +1,14 @@
 import argparse
 import sys
+
 from intersphinx_registry import __version__
+from intersphinx_registry.lookup import clear_cache, lookup_packages, print_info
+from intersphinx_registry.reverse_lookup import reverse_lookup
+from intersphinx_registry.rev_search import rev_search
+from intersphinx_registry.utils import _are_dependencies_available
 
 
 def lookup_command(args):
-    from intersphinx_registry.lookup import _are_dependencies_available, lookup_packages
-
     if not _are_dependencies_available():
         sys.exit(1)
 
@@ -59,6 +62,58 @@ def main():
         help="Optional search term to filter results",
     )
     lookup_parser.set_defaults(func=lookup_command)
+
+    reverse_lookup_parser = subparsers.add_parser(
+        "reverse-lookup",
+        help="Find which packages documentation URLs belong to",
+        description="Given URLs, find which packages they come from",
+        epilog="Examples:\n"
+        "  intersphinx-registry reverse-lookup https://numpy.org/doc/stable/reference/arrays.html\n"
+        "  intersphinx-registry reverse-lookup https://docs.python.org/3/ https://numpy.org/doc/stable/",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    reverse_lookup_parser.add_argument(
+        "urls",
+        nargs="*",
+        help="URLs to look up (space-separated)",
+    )
+
+    def _reverse_lookup_wrapper(args):
+        if not args.urls:
+            reverse_lookup_parser.print_help()
+            sys.exit(0)
+        reverse_lookup(args.urls)
+
+    reverse_lookup_parser.set_defaults(func=_reverse_lookup_wrapper)
+
+    rev_search_parser = subparsers.add_parser(
+        "rev-search",
+        help="Search .rst files for URLs that can be replaced with Sphinx references",
+        description="Scan directory for .rst files and find URLs that can be replaced",
+        epilog="Examples:\n"
+        "  intersphinx-registry rev-search docs/\n"
+        "  intersphinx-registry rev-search .",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    rev_search_parser.add_argument(
+        "directory",
+        help="Directory to search for .rst files",
+    )
+    rev_search_parser.set_defaults(func=lambda args: rev_search(args.directory))
+
+    clear_cache_parser = subparsers.add_parser(
+        "clear-cache",
+        help="Clear the intersphinx inventory cache",
+        description="Clear the cached intersphinx inventory files",
+    )
+    clear_cache_parser.set_defaults(func=lambda args: clear_cache())
+
+    info_parser = subparsers.add_parser(
+        "info",
+        help="Display information about the intersphinx-registry installation",
+        description="Show version, cache location, registry file location, and package count",
+    )
+    info_parser.set_defaults(func=lambda args: print_info())
 
     args = parser.parse_args()
 

--- a/intersphinx_registry/rev_search.py
+++ b/intersphinx_registry/rev_search.py
@@ -1,0 +1,720 @@
+import re
+from pathlib import Path
+from typing import Iterable, NamedTuple, Optional, Tuple, Union
+
+from .reverse_lookup import ReverseLookupResult, _do_reverse_lookup
+from .utils import _are_dependencies_available, _compress_user_path
+
+# ANSI escape sequences
+RED = "\033[31m"
+RED_BG = "\033[41;37m"
+GREEN = "\033[32m"
+GREEN_BG = "\033[42;30m"
+BLUE = "\033[34m"
+CYAN = "\033[36m"
+YELLOW = "\033[33m"
+YELLOW_BG = "\033[43;30m"
+RESET = "\033[0m"
+
+
+class Unchanged(str):
+    """Token representing unchanged text."""
+
+
+class Removed(str):
+    """Token representing removed text."""
+
+
+class Added(str):
+    """Token representing added text."""
+
+
+Token = Union[Unchanged, Removed, Added]
+
+# OutputReplacementContext: tuple of three token sequences
+# (context_before_tokens, target_line_tokens, context_after_tokens)
+OutputReplacementContext = Tuple[
+    Tuple[Token, ...],
+    Tuple[Token, ...],
+    Tuple[Token, ...],
+]
+
+
+def normalise_token_stream(tokens: Tuple[Token, ...]) -> Tuple[Token, ...]:
+    """
+    Normalize a token stream by:
+    1. Filtering out empty tokens
+    2. Merging consecutive tokens of the same type
+
+    This is useful for comparing token streams that are semantically
+    equivalent but may have different tokenization.
+    """
+    if not tokens:
+        return (Unchanged(""),)
+
+    normalized = []
+    current_type = None
+    current_content = ""
+
+    for token in tokens:
+        if not str(token):
+            continue
+
+        token_type = type(token)
+
+        if token_type == current_type:
+            current_content += str(token)
+        else:
+            if current_type is not None:
+                normalized.append(current_type(current_content))
+            current_type = token_type
+            current_content = str(token)
+
+    if current_type is not None:
+        normalized.append(current_type(current_content))
+
+    if not normalized:
+        return (Unchanged(""),)
+
+    return tuple(normalized)
+
+
+def _make_line_tokens(
+    line: str,
+    start: int,
+    end: int,
+    old_text: str,
+    new_text: str,
+) -> tuple[tuple[Token, ...], tuple[Token, ...]]:
+    """
+    Build old and new token lists for a line where text is replaced.
+
+    Returns (old_tokens, new_tokens) where:
+    - old_tokens: [Unchanged(prefix), Removed(old_text), Unchanged(suffix)]
+    - new_tokens: [Unchanged(prefix), Added(new_text), Unchanged(suffix)]
+    """
+    old_tokens: list[Token] = []
+    new_tokens: list[Token] = []
+
+    if start > 0:
+        prefix = Unchanged(line[:start])
+        old_tokens.append(prefix)
+        new_tokens.append(prefix)
+
+    old_tokens.append(Removed(old_text))
+    new_tokens.append(Added(new_text))
+
+    if end < len(line):
+        suffix = Unchanged(line[end:])
+        old_tokens.append(suffix)
+        new_tokens.append(suffix)
+
+    return tuple(old_tokens), tuple(new_tokens)
+
+
+class UrlReplacement(NamedTuple):
+    """
+    Information about a URL replacement in an RST file.
+
+    Attributes
+    ----------
+    line_num : int
+        Line number where the URL was found
+    matched_url : str
+        The URL that was matched in the text and replaced
+    context_old : OutputReplacementContext
+        The old context (before replacement) with tokenized (context_before_tokens, target_line_tokens, context_after_tokens)
+    context_new : OutputReplacementContext
+        The new context (after replacement) with tokenized (context_before_tokens, target_line_tokens, context_after_tokens)
+    inventory_url : Optional[str]
+        The inventory URL used for the lookup, or None
+    """
+
+    line_num: int
+    matched_url: str
+    context_old: OutputReplacementContext
+    context_new: OutputReplacementContext
+    inventory_url: Optional[str]
+
+
+class ReplacementContext(NamedTuple):
+    """
+    Context for a replacement operation.
+
+    Attributes
+    ----------
+    context_before : str
+        The context line before the target line. Empty string if there is no context before.
+    target_line : str
+        The target line to be replaced.
+    context_after : str
+        The context line after the target line. Empty string if there is no context after.
+    """
+
+    context_before: str
+    target_line: str
+    context_after: str
+
+
+def _normalize_replacement(
+    context_old: OutputReplacementContext,
+    context_new: OutputReplacementContext,
+) -> tuple[OutputReplacementContext, OutputReplacementContext]:
+    """Normalize token streams in both contexts."""
+    ctx_before_old, target_old, ctx_after_old = context_old
+    ctx_before_new, target_new, ctx_after_new = context_new
+
+    normalized_old = (
+        normalise_token_stream(ctx_before_old),
+        normalise_token_stream(target_old),
+        normalise_token_stream(ctx_after_old),
+    )
+    normalized_new = (
+        normalise_token_stream(ctx_before_new),
+        normalise_token_stream(target_new),
+        normalise_token_stream(ctx_after_new),
+    )
+    return normalized_old, normalized_new
+
+
+def _make_replacement(
+    context_before: str,
+    context_after: str,
+    target_tokens_old: tuple[Token, ...],
+    target_tokens_new: tuple[Token, ...],
+) -> tuple[OutputReplacementContext, OutputReplacementContext]:
+    """Build normalized replacement contexts with unchanged context lines."""
+    ctx = (Unchanged(context_before),), (Unchanged(context_after),)
+    context_old: OutputReplacementContext = (ctx[0], target_tokens_old, ctx[1])
+    context_new: OutputReplacementContext = (ctx[0], target_tokens_new, ctx[1])
+    return _normalize_replacement(context_old, context_new)
+
+
+# TODO:
+# I'm pretty sure instead of having a before[Unchange|Removed] and after[Unchanged|added]
+# we can have a single diff[Unchange|Removed|added] but I't more complicated to code.
+# so if you think you can do it, please feel free.
+# we can likely properly find the index of URL(s), backticks and everything,
+# split and do the replacement on the token stream/
+def _compute_full_link_replacement(
+    original_line: str,
+    context_before_str: str,
+    context_after_str: str,
+    lookup_result: ReverseLookupResult,
+    target: str,
+) -> Optional[tuple[OutputReplacementContext, OutputReplacementContext]]:
+    """
+    Handle full RST link replacement.
+
+    Handles cases like:
+    - `` `setuptools documentation <https://setuptools.pypa.io/en/latest/setuptools.html>`__ ``
+    - `` `link text <URL>`_ ``
+    - `` See `link text <URL>`__ for details ``
+
+    Returns None if the pattern doesn't match.
+    """
+    full_link_match = re.search(
+        r"`([^`<>]+)\s*<" + re.escape(lookup_result.url) + r"[.,;:!?)]*>`__?",
+        original_line,
+    )
+    if not full_link_match:
+        return None
+
+    link_text = full_link_match.group(1).strip()
+    original_text = full_link_match.group(0)
+    start_idx = full_link_match.start()
+    end_idx = full_link_match.end()
+    domain_prefix = f":{lookup_result.domain}:"
+
+    # Find where the URL is within the matched link text
+    url_match_in_link = re.search(
+        r"<" + re.escape(lookup_result.url) + r"[.,;:!?)]*>", original_text
+    )
+
+    old_tokens: list[Token] = []
+    new_tokens: list[Token] = []
+
+    # Add prefix (text before the link)
+    if start_idx > 0:
+        prefix = Unchanged(original_line[:start_idx])
+        old_tokens.append(prefix)
+        new_tokens.append(prefix)
+
+    if url_match_in_link:
+        # Fine-grained diff: show URL replacement within the link structure
+        url_start = url_match_in_link.start()
+        url_end = url_match_in_link.end()
+
+        space_before = (
+            " " if url_start > 0 and original_text[url_start - 1] == " " else ""
+        )
+
+        # Old: `link text <URL>`_  (show parts around URL as unchanged)
+        old_tokens.append(
+            Unchanged(original_text[: url_start + 1])
+        )  # up to and including <
+        old_tokens.append(
+            Removed(original_text[url_start + 1 : url_end - 1])
+        )  # URL only
+        old_tokens.append(Unchanged(original_text[url_end - 1 : url_end]))  # >
+
+        # Handle trailing backtick and underscores
+        after_angle = original_text[url_end:]
+        if after_angle.startswith("`"):
+            old_tokens.append(Unchanged(after_angle[0]))  # `
+            if len(after_angle) > 1:
+                old_tokens.append(Removed(after_angle[1:]))  # underscores
+        else:
+            old_tokens.append(Removed(after_angle))
+
+        # New: :domain:`link text <target>`
+        new_tokens.append(Added(domain_prefix))
+        new_tokens.append(Unchanged("`" + link_text + space_before + "<"))
+        new_tokens.append(Added(target))
+        new_tokens.append(Unchanged(">`"))
+    else:
+        # Simple replacement: whole link becomes role reference
+        old_tokens.append(Removed(original_text))
+        new_tokens.append(Added(domain_prefix))
+        new_tokens.append(Unchanged("`" + link_text))
+        new_tokens.append(Added(f" <{target}>`"))
+
+    # Add suffix (text after the link)
+    if end_idx < len(original_line):
+        suffix = Unchanged(original_line[end_idx:])
+        old_tokens.append(suffix)
+        new_tokens.append(suffix)
+
+    return _make_replacement(
+        context_before_str, context_after_str, tuple(old_tokens), tuple(new_tokens)
+    )
+
+
+def _compute_simple_link_replacement(
+    original_line: str,
+    context_before_str: str,
+    context_after_str: str,
+    lookup_result: ReverseLookupResult,
+    target: str,
+    rst_ref: str,
+) -> Optional[tuple[OutputReplacementContext, OutputReplacementContext]]:
+    """
+    Handle simple RST link replacement (may span multiple lines).
+
+    Handles cases like:
+    - `` `<https://docs.python.org/3/library/os.html>`_ ``
+    - `` `<https://docs.python.org/3/library/os.html>`__ ``
+    - Multi-line: context_before has `` `link text ``, target_line has `` <URL>`_ ``
+
+    Returns None if the pattern doesn't match.
+    """
+    simple_link_match = re.search(
+        r"`?<" + re.escape(lookup_result.url) + r"[.,;:!?)]*>`__?", original_line
+    )
+    if not simple_link_match:
+        return None
+
+    original_text = simple_link_match.group(0)
+    start_idx = simple_link_match.start()
+    end_idx = simple_link_match.end()
+
+    # Check if link text is on the previous line (multi-line case)
+    link_text_match = re.search(r"`([^`]+)$", context_before_str)
+    if link_text_match:
+        link_text = link_text_match.group(1).strip()
+
+        # Build context_before tokens (with changes)
+        ctx_old, ctx_new = _make_line_tokens(
+            context_before_str,
+            link_text_match.start(),
+            link_text_match.end(),
+            context_before_str[link_text_match.start() : link_text_match.end()],
+            f":{lookup_result.domain}:`{link_text}",
+        )
+
+        # Build target line tokens
+        target_old, target_new = _make_line_tokens(
+            original_line, start_idx, end_idx, original_text, f"<{target}>`"
+        )
+
+        ctx_after = (Unchanged(context_after_str),)
+        context_old: OutputReplacementContext = (ctx_old, target_old, ctx_after)
+        context_new: OutputReplacementContext = (ctx_new, target_new, ctx_after)
+        return _normalize_replacement(context_old, context_new)
+
+    # Simple case: just replace the link on the target line
+    old_tokens, new_tokens = _make_line_tokens(
+        original_line, start_idx, end_idx, original_text, rst_ref
+    )
+    return _make_replacement(
+        context_before_str, context_after_str, old_tokens, new_tokens
+    )
+
+
+def _compute_url_replacement(
+    original_line: str,
+    context_before_str: str,
+    context_after_str: str,
+    lookup_result: ReverseLookupResult,
+    rst_ref: str,
+) -> tuple[OutputReplacementContext, OutputReplacementContext]:
+    """
+    Handle plain URL replacement in text.
+
+    Handles cases like:
+    - `` See https://docs.python.org/3/library/os.html for details ``
+    - `` Check https://docs.python.org/3/library/os.html. ``
+    - `` https://docs.python.org/3/library/os.html is the documentation ``
+
+    This is the fallback case when no RST link pattern matches.
+    """
+    url_match = re.search(re.escape(lookup_result.url) + r"[.,;:!?)]*", original_line)
+    if url_match:
+        old_tokens, new_tokens = _make_line_tokens(
+            original_line,
+            url_match.start(),
+            url_match.end(),
+            lookup_result.url,
+            rst_ref,
+        )
+    else:
+        old_tokens = (Removed(original_line),)
+        new_tokens = (Added(rst_ref),)
+
+    return _make_replacement(
+        context_before_str, context_after_str, old_tokens, new_tokens
+    )
+
+
+def _compute_replacement(
+    original: ReplacementContext,
+    lookup_result: ReverseLookupResult,
+) -> tuple[OutputReplacementContext, OutputReplacementContext]:
+    """
+    Compute the replacement line(s) for a URL in an RST file.
+
+    Tries patterns in order: full RST link, simple link, plain URL.
+    Returns (context_old, context_new) tuple of normalized token streams.
+    """
+    target = f"{lookup_result.package}:{lookup_result.rst_entry}"
+    rst_ref = f":{lookup_result.domain}:`{target}`"
+    ctx_before, line, ctx_after = original
+
+    result = _compute_full_link_replacement(
+        line, ctx_before, ctx_after, lookup_result, target
+    )
+    if result is not None:
+        return result
+
+    result = _compute_simple_link_replacement(
+        line, ctx_before, ctx_after, lookup_result, target, rst_ref
+    )
+    if result is not None:
+        return result
+
+    return _compute_url_replacement(line, ctx_before, ctx_after, lookup_result, rst_ref)
+
+
+def process_one_file(rst_file: Path):
+    """
+    Process a single RST file to find URLs that can be replaced with Sphinx references.
+
+    Yields UrlReplacement objects for each URL found that has a corresponding
+    inventory entry. Files are read, URLs are extracted and looked up, and
+    replacements are computed with token-based diffs.
+
+    Parameters
+    ----------
+    rst_file : Path
+        Path to the RST file to process
+
+    Yields
+    ------
+    UrlReplacement
+        Information about each URL replacement found in the file
+    """
+    url_pattern = re.compile(r'https?://[^\s<>"{}|\\^`\[\]]+')
+    url_locations: dict[str, list[tuple[int, str]]] = {}
+    all_lines = []
+
+    try:
+        with open(rst_file, "r", encoding="utf-8") as f:
+            all_lines = f.readlines()
+            for line_num, line in enumerate(all_lines, start=1):
+                urls = url_pattern.findall(line)
+                for url in urls:
+                    url = url.rstrip(".,;:!?)")
+                    url_locations.setdefault(url, []).append((line_num, line.rstrip()))
+    except Exception:
+        return
+
+    if not url_locations:
+        return
+
+    urls = list(url_locations.keys())
+    results = _do_reverse_lookup(urls)
+
+    replaceable = [
+        (result, url_locations[result.url])
+        for result in results
+        if result.package is not None
+    ]
+
+    if not replaceable:
+        return
+
+    for lookup_result, line_infos in replaceable:
+        for line_num, original_line in line_infos:
+            context_before = all_lines[line_num - 2].rstrip() if line_num > 1 else ""
+            context_after = (
+                all_lines[line_num].rstrip() if line_num < len(all_lines) else ""
+            )
+
+            if lookup_result.rst_entry is not None:
+                context_old, context_new = _compute_replacement(
+                    ReplacementContext(context_before, original_line, context_after),
+                    lookup_result,
+                )
+                yield UrlReplacement(
+                    line_num,
+                    lookup_result.url,
+                    context_old,
+                    context_new,
+                    lookup_result.inventory_url,
+                )
+            else:
+                # No replacement available - create empty contexts
+                empty_context: OutputReplacementContext = (
+                    (Unchanged(context_before),),
+                    (Unchanged(original_line),),
+                    (Unchanged(context_after),),
+                )
+                yield UrlReplacement(
+                    line_num,
+                    lookup_result.url,
+                    empty_context,
+                    empty_context,
+                    lookup_result.inventory_url,
+                )
+
+
+def format_tokens(
+    tokens: Tuple[Token, ...],
+    prefix: str = "",
+    defaultFG: str = "",
+    AddedHighlight: str = "",
+    RemovedHighlight: str = "",
+) -> str:
+    """
+    Format tokens with appropriate colors.
+
+    Parameters
+    ----------
+    tokens : Tuple[Token, ...]
+        Sequence of tokens to format
+    prefix : str
+        Prefix to add before the tokens (e.g., "     - " or "       ")
+    defaultFG : str
+        Default foreground color for the line (e.g., RED, GREEN, BLUE). Empty string for no color.
+    AddedHighlight : str
+        Highlight style for Added tokens (e.g., GREEN_BG for background). Empty string for no highlight.
+    RemovedHighlight : str
+        Highlight style for Removed tokens (e.g., RED_BG for background). Empty string for no highlight.
+
+    Returns
+    -------
+    str
+        Formatted string with ANSI color codes
+    """
+    if not tokens:
+        return ""
+
+    output = ""
+    # Add prefix with defaultFG color
+    output += defaultFG + prefix + RESET + defaultFG
+
+    for token in tokens:
+        if isinstance(token, Added):
+            output += f"{AddedHighlight}{str(token)}{RESET}{defaultFG}"
+        elif isinstance(token, Removed):
+            output += f"{RemovedHighlight}{str(token)}{RESET}{defaultFG}"
+        else:  # Unchanged
+            output += str(token)
+
+    output += RESET
+
+    return output
+
+
+def rev_search(directory: str) -> None:
+    """
+    Search for URLs in .rst files that can be replaced with Sphinx references.
+
+    Parameters
+    ----------
+    directory : str
+        Path to a directory to search for .rst files, or a single .rst file path
+    """
+    if not _are_dependencies_available():
+        return
+
+    directory_path = Path(directory)
+    if directory_path.is_file():
+        rst_files: Iterable[Path] = (
+            [directory_path] if directory_path.suffix == ".rst" else []
+        )
+    else:
+        rst_files = directory_path.rglob("*.rst")
+
+    for rst_file in rst_files:
+        search_one_file(rst_file)
+
+
+def search_one_file(rst_file: Path) -> None:
+    """
+    Search a single RST file and print formatted diffs for replaceable URLs.
+
+    Processes the file to find replaceable URLs and prints a formatted diff
+    showing the original and replacement text with color-coded token highlights.
+
+    Parameters
+    ----------
+    rst_file : Path
+        Path to the RST file to search and display results for
+    """
+    display_path = _compress_user_path(str(rst_file))
+    for replacement in process_one_file(rst_file):
+        print(f"{CYAN}{display_path}:{replacement.line_num}{RESET}")
+
+        if replacement.context_old == replacement.context_new:
+            ctx_before_tokens_old, target_tokens_old, ctx_after_tokens_old = (
+                replacement.context_old
+            )
+
+            if ctx_before_tokens_old:
+                print(format_tokens(ctx_before_tokens_old, "       "))
+
+            print(format_tokens(target_tokens_old, "     ? ", defaultFG=BLUE))
+
+            if ctx_after_tokens_old:
+                print(format_tokens(ctx_after_tokens_old, "       "))
+
+            print()
+            continue
+
+        ctx_before_tokens_old, target_tokens_old, ctx_after_tokens_old = (
+            replacement.context_old
+        )
+        ctx_before_tokens_new, target_tokens_new, ctx_after_tokens_new = (
+            replacement.context_new
+        )
+
+        if ctx_before_tokens_old or ctx_before_tokens_new:
+            if ctx_before_tokens_old != ctx_before_tokens_new:
+                print(
+                    format_tokens(
+                        ctx_before_tokens_old,
+                        "     - ",
+                        defaultFG=RED,
+                        RemovedHighlight=RED_BG,
+                    )
+                )
+            else:
+                print(format_tokens(ctx_before_tokens_old, "       "))
+        print(
+            format_tokens(
+                target_tokens_old, "     - ", defaultFG=RED, RemovedHighlight=RED_BG
+            )
+        )
+
+        if replacement.inventory_url:
+            old_text = "".join(
+                str(token)
+                for token in target_tokens_old
+                if not isinstance(token, Added)
+            )
+            if replacement.inventory_url not in old_text:
+                https_pos = old_text.find("https://")
+                if https_pos >= 0:
+                    spaces = " " * (7 + https_pos)
+                else:
+                    spaces = "       "
+
+                matched_url = replacement.matched_url
+                inventory_url = replacement.inventory_url
+
+                prefix_len = 0
+                while (
+                    prefix_len < len(matched_url)
+                    and prefix_len < len(inventory_url)
+                    and matched_url[prefix_len] == inventory_url[prefix_len]
+                ):
+                    prefix_len += 1
+
+                suffix_len = 0
+                while (
+                    suffix_len < len(matched_url) - prefix_len
+                    and suffix_len < len(inventory_url) - prefix_len
+                    and matched_url[-(suffix_len + 1)]
+                    == inventory_url[-(suffix_len + 1)]
+                ):
+                    suffix_len += 1
+
+                if prefix_len > 0 or suffix_len > 0:
+                    prefix = inventory_url[:prefix_len]
+                    middle = (
+                        inventory_url[prefix_len : len(inventory_url) - suffix_len]
+                        if suffix_len > 0
+                        else inventory_url[prefix_len:]
+                    )
+                    suffix = inventory_url[-suffix_len:] if suffix_len > 0 else ""
+                    highlighted_url = f"{YELLOW}{prefix}{YELLOW_BG}{middle}{RESET}{YELLOW}{suffix}{RESET}"
+                else:
+                    highlighted_url = f"{YELLOW_BG}{inventory_url}{RESET}"
+
+                print(f"{spaces}{highlighted_url}")
+
+        if ctx_before_tokens_old or ctx_before_tokens_new:
+            if ctx_before_tokens_old != ctx_before_tokens_new:
+                print(
+                    format_tokens(
+                        ctx_before_tokens_new,
+                        "     + ",
+                        defaultFG=GREEN,
+                        AddedHighlight=GREEN_BG,
+                        RemovedHighlight=RED_BG,
+                    )
+                )
+        print(
+            format_tokens(
+                target_tokens_new,
+                "     + ",
+                defaultFG=GREEN,
+                AddedHighlight=GREEN_BG,
+                RemovedHighlight=RED_BG,
+            )
+        )
+
+        if ctx_after_tokens_old or ctx_after_tokens_new:
+            if ctx_after_tokens_old != ctx_after_tokens_new:
+                print(
+                    format_tokens(
+                        ctx_after_tokens_old,
+                        "     - ",
+                        defaultFG=RED,
+                        RemovedHighlight=RED_BG,
+                    )
+                )
+                print(
+                    format_tokens(
+                        ctx_after_tokens_new,
+                        "     + ",
+                        defaultFG=GREEN,
+                        AddedHighlight=GREEN_BG,
+                        RemovedHighlight=RED_BG,
+                    )
+                )
+            else:
+                print(format_tokens(ctx_after_tokens_old, "       "))
+
+        print()

--- a/intersphinx_registry/reverse_lookup.py
+++ b/intersphinx_registry/reverse_lookup.py
@@ -1,0 +1,247 @@
+import json
+import re
+import sys
+import warnings
+from collections import namedtuple
+from io import BytesIO
+from pathlib import Path
+from urllib.parse import urljoin, urlparse
+
+import requests
+from sphinx.util.inventory import InventoryFile
+
+from .utils import _are_dependencies_available, _install_cache
+
+ReverseLookupResult = namedtuple(
+    "ReverseLookupResult",
+    ["url", "package", "domain", "rst_entry", "display_name", "inventory_url"],
+)
+
+
+def _normalize_url_for_matching(url: str) -> str:
+    """
+    Normalize URL for fuzzy matching by removing version-specific segments.
+
+    This helps match URLs like:
+    - /stable/ vs /latest/ vs /main/
+    - /v1.2.3/ vs /v2.0/ vs /1.5/
+    """
+    normalized = re.sub(r"/(latest|stable|main|dev|master)/", "/_VERSION_/", url)
+    normalized = re.sub(r"/v?\d+(\.\d+)*/", "/_VERSION_/", normalized)
+    return normalized
+
+
+def uri_match(user_url: str, inv_url: str) -> bool:
+    """
+    Check if two URIs match, handling index.html variations and version normalization.
+
+    Parameters
+    ----------
+    user_url : str
+        URL from user input or RST file
+    inv_url : str
+        URL from intersphinx inventory
+
+    Returns
+    -------
+    bool
+        True if the URLs match (considering index.html and version variations), False otherwise
+    """
+    if user_url == inv_url:
+        return True
+
+    variants = [user_url]
+    if user_url.endswith("/index.html"):
+        variants.append(user_url[:-10])  # Remove index.html, keep /
+    elif user_url.endswith("/"):
+        variants.append(user_url + "index.html")
+    else:
+        variants.append(user_url + "/index.html")
+
+    if inv_url in variants:
+        return True
+
+    inv_url_normalized = (
+        _normalize_url_for_matching(inv_url).rstrip("/").replace("/index.html", "")
+    )
+    for variant in variants:
+        variant_normalized = (
+            _normalize_url_for_matching(variant).rstrip("/").replace("/index.html", "")
+        )
+        if variant_normalized == inv_url_normalized:
+            return True
+
+    return False
+
+
+def _do_reverse_lookup(
+    urls: list[str],
+) -> list[ReverseLookupResult]:
+    """
+    Core reverse lookup logic: given URLs, find which packages they belong to and their rst references.
+
+    Parameters
+    ----------
+    urls : list[str]
+        List of URLs
+
+    Returns
+    -------
+    list[ReverseLookupResult]
+        List of ReverseLookupResult named tuples with fields:
+        url, package, domain, rst_entry, display_name
+    """
+    _install_cache()
+
+    registry_file = Path(__file__).parent / "registry.json"
+    registry = json.loads(registry_file.read_bytes())
+
+    package_urls: dict[str, list[str]] = {}
+
+    for url_str in urls:
+        matched = False
+        for package, (base_url, obj_path) in registry.items():
+            if url_str.startswith(base_url):
+                package_urls.setdefault(package, []).append(url_str)
+                matched = True
+                break
+
+        if not matched:
+            url_domain = urlparse(url_str).netloc
+            url_path_normalized = (
+                _normalize_url_for_matching(urlparse(url_str).path)
+                .rstrip("/")
+                .replace("/index.html", "")
+            )
+
+            for package, (base_url, obj_path) in registry.items():
+                base_domain = urlparse(base_url).netloc
+                if url_domain == base_domain:
+                    base_path_normalized = _normalize_url_for_matching(
+                        urlparse(base_url).path
+                    ).rstrip("/")
+                    if url_path_normalized.startswith(
+                        base_path_normalized
+                    ) or base_path_normalized.startswith(url_path_normalized):
+                        package_urls.setdefault(package, []).append(url_str)
+                        break
+
+    results: list[ReverseLookupResult] = []
+
+    for package, url_list in package_urls.items():
+        base_url, obj_path = registry[package]
+        inv_url = urljoin(base_url, obj_path if obj_path else "objects.inv")
+
+        try:
+            resp = requests.get(inv_url, timeout=25)
+            resp.raise_for_status()
+            inv = InventoryFile.load(BytesIO(resp.content), base_url, urljoin)
+        except Exception as e:
+            warnings.warn(
+                f"Failed to load inventory for '{package}' from {inv_url}: {e}",
+                UserWarning,
+                stacklevel=2,
+            )
+            for url_str in url_list:
+                results.append(
+                    ReverseLookupResult(url_str, package, None, None, None, None)
+                )
+            continue
+
+        inv_urls = {}
+        for key, v in inv.items():
+            for entry, (proj, ver, uri, display_name) in v.items():
+                inv_urls[uri] = (key, entry, display_name)
+
+        for url_str in url_list:
+            found = False
+
+            for inv_uri, (key, entry, display_name) in inv_urls.items():
+                if uri_match(url_str, inv_uri):
+                    results.append(
+                        ReverseLookupResult(
+                            url_str, package, key, entry, display_name, inv_uri
+                        )
+                    )
+                    found = True
+                    break
+
+            if not found:
+                results.append(
+                    ReverseLookupResult(url_str, package, None, None, None, None)
+                )
+
+    return results
+
+
+def _print_reverse_lookup_results(
+    results: list[ReverseLookupResult],
+) -> None:
+    """
+    Print formatted reverse lookup results.
+
+    Parameters
+    ----------
+    results : list[ReverseLookupResult]
+        List of ReverseLookupResult named tuples
+    """
+    if not results:
+        return
+
+    header_url = "URL"
+    header_rst = "Sphinx Reference"
+    header_display = "Description"
+
+    width_url = max(len(header_url), max(len(r.url) for r in results))
+    width_rst = max(
+        len(header_rst),
+        max(
+            (
+                len(f":{r.domain}:`{r.package}:{r.rst_entry}`")
+                if r.rst_entry
+                else len("NOT FOUND")
+            )
+            for r in results
+        ),
+    )
+    width_display = max(
+        len(header_display),
+        max((len(r.display_name) if r.display_name else 0) for r in results),
+    )
+
+    print(f"{header_url:<{width_url}}  {header_rst:<{width_rst}}  {header_display}")
+    print(f"{'-' * width_url}  {'-' * width_rst}  {'-' * width_display}")
+
+    for result in results:
+        if result.rst_entry:
+            rst_ref = f":{result.domain}:`{result.package}:{result.rst_entry}`"
+            display = (
+                result.display_name
+                if result.display_name and result.display_name != "-"
+                else result.rst_entry
+            )
+            print(
+                f"{result.url:<{width_url}}  {rst_ref:<{width_rst}}  {display:<{width_display}}"
+            )
+        elif result.package:
+            print(f"{result.url:<{width_url}}  {'NOT FOUND':<{width_rst}}")
+
+
+def reverse_lookup(urls: list[str]) -> None:
+    """
+    Reverse lookup: given URLs, find which packages they belong to and their rst references.
+
+    Parameters
+    ----------
+    urls : list[str]
+        List of URLs
+    """
+    if not urls:
+        print("ERROR: No URLs provided", file=sys.stderr)
+        return
+
+    if not _are_dependencies_available():
+        return
+
+    results = _do_reverse_lookup(urls)
+    _print_reverse_lookup_results(results)

--- a/intersphinx_registry/utils.py
+++ b/intersphinx_registry/utils.py
@@ -1,0 +1,125 @@
+import shutil
+import sys
+from datetime import timedelta
+from pathlib import Path
+
+import platformdirs
+import requests_cache
+
+from . import __version__
+
+
+def _compress_user_path(path: str) -> str:
+    """
+    Replace home directory with ~ in a path string.
+
+    Parameters
+    ----------
+    path : str
+        Path to compress
+
+    Returns
+    -------
+    str
+        Path with home directory replaced by ~
+    """
+    home = str(Path.home())
+    if path.startswith(home):
+        return path.replace(home, "~", 1)
+    return path
+
+
+def _get_cache_dir() -> Path:
+    """
+    Get the cache directory for the current version of intersphinx_registry.
+
+    Returns
+    -------
+    Path
+        Cache directory path with version subdirectory
+    """
+    base_cache_dir = Path(platformdirs.user_cache_dir("intersphinx_registry"))
+    cache_dir = base_cache_dir / __version__
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    return cache_dir
+
+
+def _cleanup_old_caches() -> None:
+    """
+    Remove cache directories from old versions of intersphinx_registry.
+    Only keeps the current version's cache.
+    """
+    base_cache_dir = Path(platformdirs.user_cache_dir("intersphinx_registry"))
+
+    if not base_cache_dir.exists():
+        return
+
+    current_version = __version__
+
+    for version_dir in base_cache_dir.iterdir():
+        if version_dir.is_dir() and version_dir.name != current_version:
+            try:
+                shutil.rmtree(version_dir)
+            except Exception:
+                pass
+
+
+def _install_cache() -> None:
+    """
+    Install the version-specific requests cache.
+    Cleans up old caches on first use.
+    """
+    _cleanup_old_caches()
+
+    cache_dir = _get_cache_dir()
+    cache_path = cache_dir / "intersphinx_cache.sqlite"
+
+    requests_cache.install_cache(
+        str(cache_path),
+        backend="sqlite",
+        expire_after=timedelta(hours=6),
+        stale_if_error=True,
+        cache_control=True,
+    )
+
+
+def _are_dependencies_available() -> bool:
+    """
+    Check if CLI dependencies are missing or not.
+    Returns True if all dependencies are available, False otherwise.
+    """
+    missing = []
+    try:
+        import sphinx  # noqa: F401
+    except ModuleNotFoundError:
+        missing.append("sphinx")
+
+    try:
+        import requests  # noqa: F401
+    except ModuleNotFoundError:
+        missing.append("requests")
+
+    try:
+        import requests_cache  # noqa: F401
+    except ModuleNotFoundError:
+        missing.append("requests-cache")
+
+    try:
+        import platformdirs  # noqa: F401
+    except ModuleNotFoundError:
+        missing.append("platformdirs")
+
+    if missing:
+        print(
+            "ERROR: the lookup functionality requires additional dependencies.",
+            file=sys.stderr,
+        )
+        print(
+            "Please install with: pip install 'intersphinx_registry[cli]'",
+            file=sys.stderr,
+        )
+        print(f"Missing dependencies: {', '.join(missing)}", file=sys.stderr)
+        return False
+
+    return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,15 +4,15 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "intersphinx_registry"
-authors = [{name = "Matthias Bussonnier", email = "bussonniermatthias@gmail.com"}]
+authors = [{name = "M Bussonnier", email = "bussonniermatthias@gmail.com"}]
 license = {file = "LICENSE"}
 classifiers = ["License :: OSI Approved :: MIT License"]
 dynamic = ["version", "description"]
 readme = "README.md"
 
 [project.optional-dependencies]
-tests = ["pytest>=7.0", "pytest-xdist", "mypy", "types-requests"]
-lookup = ["sphinx", "requests"]
+tests = ["pytest>=7.0", "pytest-xdist", "mypy", "types-requests",'intersphinx_registry[cli]']
+lookup = ["sphinx>=8", "requests", "requests-cache", "platformdirs"]
 cli = ["intersphinx_registry[lookup]"]
 
 [project.scripts]
@@ -31,6 +31,12 @@ xfail_strict = true
 
 [tool.mypy]
 files = ["intersphinx_registry", "tests"]
+
+[tool.ruff.lint]
+extend-select = ["I"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["intersphinx_registry"]
 
 [project.urls]
 Home = "https://github.com/Quansight-labs/intersphinx_registry"

--- a/tests/test_rev_search_tokens.py
+++ b/tests/test_rev_search_tokens.py
@@ -1,0 +1,271 @@
+"""Tests for rev_search tokenization."""
+
+import warnings
+
+import pytest
+
+from intersphinx_registry.rev_search import (
+    Added,
+    ReplacementContext,
+    Removed,
+    Unchanged,
+    _compute_replacement,
+    normalise_token_stream,
+)
+from intersphinx_registry.reverse_lookup import ReverseLookupResult
+
+
+@pytest.mark.parametrize(
+    "original,lookup_result,expected",
+    [
+        # Test case 1: Full link on its own line (no prefix in line, prefix in context_before)
+        (
+            ReplacementContext(
+                "For more details, see the",
+                "`setuptools documentation <https://setuptools.pypa.io/en/latest/setuptools.html>`__",
+                "",
+            ),
+            ReverseLookupResult(
+                "https://setuptools.pypa.io/en/latest/setuptools.html",
+                "setuptools",
+                "std:doc",
+                "setuptools",
+                None,
+                "https://setuptools.pypa.io/en/latest/setuptools.html",
+            ),
+            (
+                (
+                    (Unchanged("For more details, see the"),),
+                    (
+                        Unchanged("`setuptools documentation <"),
+                        Removed("https://setuptools.pypa.io/en/latest/setuptools.html"),
+                        Unchanged(">`"),
+                        Removed("__"),
+                    ),
+                    (Unchanged(""),),
+                ),
+                (
+                    (Unchanged("For more details, see the"),),
+                    (
+                        Added(":std:doc:"),
+                        Unchanged("`setuptools documentation <"),
+                        Added("setuptools:setuptools"),
+                        Unchanged(">`"),
+                    ),
+                    (Unchanged(""),),
+                ),
+            ),
+        ),
+        # Test case 2: Full link with prefix text in the same line
+        (
+            ReplacementContext(
+                "",
+                "For more details, see the `setuptools documentation <https://setuptools.pypa.io/en/latest/setuptools.html>`__",
+                "",
+            ),
+            ReverseLookupResult(
+                "https://setuptools.pypa.io/en/latest/setuptools.html",
+                "setuptools",
+                "std:doc",
+                "setuptools",
+                None,
+                "https://setuptools.pypa.io/en/latest/setuptools.html",
+            ),
+            (
+                (
+                    (Unchanged(""),),
+                    (
+                        Unchanged(
+                            "For more details, see the `setuptools documentation <"
+                        ),
+                        Removed("https://setuptools.pypa.io/en/latest/setuptools.html"),
+                        Unchanged(">`"),
+                        Removed("__"),
+                    ),
+                    (Unchanged(""),),
+                ),
+                (
+                    (Unchanged(""),),
+                    (
+                        Unchanged("For more details, see the "),
+                        Added(":std:doc:"),
+                        Unchanged("`setuptools documentation <"),
+                        Added("setuptools:setuptools"),
+                        Unchanged(">`"),
+                    ),
+                    (Unchanged(""),),
+                ),
+            ),
+        ),
+        # Test case 3: Full link with suffix text
+        (
+            ReplacementContext(
+                "",
+                "`setuptools documentation <https://setuptools.pypa.io/en/latest/setuptools.html>`__ for details",
+                "",
+            ),
+            ReverseLookupResult(
+                "https://setuptools.pypa.io/en/latest/setuptools.html",
+                "setuptools",
+                "std:doc",
+                "setuptools",
+                None,
+                "https://setuptools.pypa.io/en/latest/setuptools.html",
+            ),
+            (
+                (
+                    (Unchanged(""),),
+                    (
+                        Unchanged("`setuptools documentation <"),
+                        Removed("https://setuptools.pypa.io/en/latest/setuptools.html"),
+                        Unchanged(">`"),
+                        Removed("__"),
+                        Unchanged(" for details"),
+                    ),
+                    (Unchanged(""),),
+                ),
+                (
+                    (Unchanged(""),),
+                    (
+                        Added(":std:doc:"),
+                        Unchanged("`setuptools documentation <"),
+                        Added("setuptools:setuptools"),
+                        Unchanged(">` for details"),
+                    ),
+                    (Unchanged(""),),
+                ),
+            ),
+        ),
+        # Test case 4: Full link with both prefix and suffix
+        (
+            ReplacementContext(
+                "",
+                "See `setuptools documentation <https://setuptools.pypa.io/en/latest/setuptools.html>`__ for details",
+                "",
+            ),
+            ReverseLookupResult(
+                "https://setuptools.pypa.io/en/latest/setuptools.html",
+                "setuptools",
+                "std:doc",
+                "setuptools",
+                None,
+                "https://setuptools.pypa.io/en/latest/setuptools.html",
+            ),
+            (
+                (
+                    (Unchanged(""),),
+                    (
+                        Unchanged("See `setuptools documentation <"),
+                        Removed("https://setuptools.pypa.io/en/latest/setuptools.html"),
+                        Unchanged(">`"),
+                        Removed("__"),
+                        Unchanged(" for details"),
+                    ),
+                    (Unchanged(""),),
+                ),
+                (
+                    (Unchanged(""),),
+                    (
+                        Unchanged("See "),
+                        Added(":std:doc:"),
+                        Unchanged("`setuptools documentation <"),
+                        Added("setuptools:setuptools"),
+                        Unchanged(">` for details"),
+                    ),
+                    (Unchanged(""),),
+                ),
+            ),
+        ),
+    ],
+    ids=[
+        "link_only_line",
+        "link_with_prefix_in_line",
+        "link_with_suffix",
+        "link_with_prefix_and_suffix",
+    ],
+)
+def test_full_link_tokenization(original, lookup_result, expected):
+    """Test that full link replacement tokenizes correctly."""
+    context_old, context_new = _compute_replacement(original, lookup_result)
+    expected_old, expected_new = expected
+
+    # Check if expected is already normalized and warn if not
+    exp_before_old, exp_target_old, exp_after_old = expected_old
+    exp_before_new, exp_target_new, exp_after_new = expected_new
+
+    if normalise_token_stream(exp_before_old) != exp_before_old:
+        normalized = normalise_token_stream(exp_before_old)
+        warnings.warn(
+            f"expected_old context_before is not normalized.\n"
+            f"  Original: {exp_before_old}\n"
+            f"  Normalized: {normalized}",
+            UserWarning,
+        )
+    if normalise_token_stream(exp_target_old) != exp_target_old:
+        normalized = normalise_token_stream(exp_target_old)
+        warnings.warn(
+            f"expected_old target_line is not normalized.\n"
+            f"  Original: {exp_target_old}\n"
+            f"  Normalized: {normalized}",
+            UserWarning,
+        )
+    if normalise_token_stream(exp_after_old) != exp_after_old:
+        normalized = normalise_token_stream(exp_after_old)
+        warnings.warn(
+            f"expected_old context_after is not normalized.\n"
+            f"  Original: {exp_after_old}\n"
+            f"  Normalized: {normalized}",
+            UserWarning,
+        )
+    if normalise_token_stream(exp_before_new) != exp_before_new:
+        normalized = normalise_token_stream(exp_before_new)
+        warnings.warn(
+            f"expected_new context_before is not normalized.\n"
+            f"  Original: {exp_before_new}\n"
+            f"  Normalized: {normalized}",
+            UserWarning,
+        )
+    if normalise_token_stream(exp_target_new) != exp_target_new:
+        normalized = normalise_token_stream(exp_target_new)
+        warnings.warn(
+            f"expected_new target_line is not normalized.\n"
+            f"  Original: {exp_target_new}\n"
+            f"  Normalized: {normalized}",
+            UserWarning,
+        )
+    if normalise_token_stream(exp_after_new) != exp_after_new:
+        normalized = normalise_token_stream(exp_after_new)
+        warnings.warn(
+            f"expected_new context_after is not normalized.\n"
+            f"  Original: {exp_after_new}\n"
+            f"  Normalized: {normalized}",
+            UserWarning,
+        )
+
+    # Normalize both actual and expected streams before comparing
+    ctx_before_old, target_old, ctx_after_old = context_old
+    ctx_before_new, target_new, ctx_after_new = context_new
+
+    normalized_context_old = (
+        normalise_token_stream(ctx_before_old),
+        normalise_token_stream(target_old),
+        normalise_token_stream(ctx_after_old),
+    )
+    normalized_context_new = (
+        normalise_token_stream(ctx_before_new),
+        normalise_token_stream(target_new),
+        normalise_token_stream(ctx_after_new),
+    )
+    normalized_expected_old = (
+        normalise_token_stream(exp_before_old),
+        normalise_token_stream(exp_target_old),
+        normalise_token_stream(exp_after_old),
+    )
+    normalized_expected_new = (
+        normalise_token_stream(exp_before_new),
+        normalise_token_stream(exp_target_new),
+        normalise_token_stream(exp_after_new),
+    )
+
+    assert normalized_context_old == normalized_expected_old, "context_old mismatch"
+    assert normalized_context_new == normalized_expected_new, "context_new mismatch"


### PR DESCRIPTION
Add tools to help convert hardcoded URLs in documentation to proper
intersphinx references, plus caching to improve performance.

## New commands:

### reverse-lookup

`reverse-lookup` - Convert URLs to intersphinx references
Given a documentation URL, finds the corresponding Sphinx reference
syntax to use in your RST files.

Usage:

```
intersphinx-registry reverse-lookup <url>...
```
Example:

```
intersphinx-registry reverse-lookup https://numpy.org/doc/stable/reference/arrays.html
```

Or reverse-lookup all url in a given dir.

```
grep -RhoE --include="*.rst" 'https?://[^"'\'' <>]*' . | sort | uniq |xargs python -m intersphinx_registry rev
```

In order to do than implement rev-search which is _mostly_ aesthetic and
caching loop with prettprinting with a lot of edge cases, implements
rev-search.

### reverse-lookup

`rev-search` - Scan RST files for replaceable URLs
Scans a directory for .rst files, finds hardcoded documentation URLs,
and displays a diff showing how each can be replaced with intersphinx
references.

Usage:

```
intersphinx-registry rev-search <directory>
```

Example:

```
intersphinx-registry rev-search docs/
```

### `clear-cache`, and `info`


`clear-cache` - Clear downloaded inventory cache
Removes cached intersphinx inventory files.

`info` - Display installation and cache information

## Caching:
Intersphinx inventories are now cached locally to avoid repeated
downloads, significantly improving lookup performance, and avoiding
bans.



---  
En example of running it in numpy:

```
numpy $ python -m intersphinx_registry rev-search doc/source/reference/
```

<img width="682" height="303" alt="Screenshot 2025-12-12 at 20 11 45" src="https://github.com/user-attachments/assets/310913ee-53b3-4871-9ebc-5cfeb22b17e5" />

You can see

- Yellow: an approximate match (logic is minimal, it tried to detect `VERSION` in url and/or `/|/index.html` and suggest replacement.

- Blue: A domain that's matches but the page is not found, possible typo: `https://docs.python.org/3/c-api/intro.html?reference-count-details` (indeed it's not `?` but `#`); [^1]

- Red/Green : and exact match and suggested replacement.


[1^]:note that this is not always the case as sphinx may add anchors to titles that don't have `.. _labels:`, and that `.. _labels:` can also generate `<span id='..'>` so clicking on a header to get the link and reverse-searching it does not always work (I'm looking for solutions here). Also link-check does not catch that, because `#fragments` and `?parameters=` don't return 404.


