### PR TITLE
Drop `commonmark-py` from the registry

### DIFF
--- a/intersphinx_registry/registry.json
+++ b/intersphinx_registry/registry.json
@@ -16,7 +16,6 @@
   "cffi": ["https://cffi.readthedocs.io/en/latest/", null],
   "click": ["https://click.palletsprojects.com/", null],
   "cloudpathlib": ["https://cloudpathlib.drivendata.org/stable/", null],
-  "commonmark": ["https://commonmarkpy.readthedocs.io/en/stable/", null],
   "conda": ["https://docs.conda.io/projects/conda/en/stable/", null],
   "conda-build": ["https://docs.conda.io/projects/conda-build/en/stable/", null],
   "configspace": ["https://automl.github.io/ConfigSpace/latest/", null],


### PR DESCRIPTION
The project has been deprecated for many years and was archived on GitHub on May 29, 2026. Read the archival notice here: https://github.com/readthedocs/commonmark.py/issues/308. The Read The Docs documentation website has been taken down and points to a 404.