### PR TITLE
Add links to pyqt6 and pyside6

### DIFF
--- a/intersphinx_registry/registry.json
+++ b/intersphinx_registry/registry.json
@@ -141,6 +141,8 @@
   "pypug": ["https://packaging.python.org/en/latest/", null],
   "pypy": ["https://doc.pypy.org/", null],
   "pyqt": ["https://www.riverbankcomputing.com/static/Docs/PyQt5/", null],
+  "pyqt5": [ "https://www.riverbankcomputing.com/static/Docs/PyQt5/", null ],
+  "pyqt6": [ "https://www.riverbankcomputing.com/static/Docs/PyQt6/", null ],
   "pyqtgraph": ["https://pyqtgraph.readthedocs.io/en/latest/", null],
   "pyro": ["https://docs.pyro.ai/en/stable/", null],
   "pytest": ["https://pytest.org/en/stable/", null],

--- a/intersphinx_registry/registry.json
+++ b/intersphinx_registry/registry.json
@@ -145,6 +145,7 @@
   "pyqt6": [ "https://www.riverbankcomputing.com/static/Docs/PyQt6/", null ],
   "pyqtgraph": ["https://pyqtgraph.readthedocs.io/en/latest/", null],
   "pyro": ["https://docs.pyro.ai/en/stable/", null],
+  "pyside6": ["https://doc.qt.io/qtforpython-6/", null],
   "pytest": ["https://pytest.org/en/stable/", null],
   "python": ["https://docs.python.org/3/", null],
   "python-guide": ["https://docs.python-guide.org/", null],

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -74,13 +74,15 @@ def test_unique_base_urls():
     Two packages should not have the same base URL.
     This is important for reverse lookup functionality to work correctly.
     """
+    DUPLICATE_EXCLUSION = {"pyqt", "pyqt5"}
     base_urls = {}
     for package, (base_url, _obj) in MAPPING.items():
         if base_url in base_urls:
-            pytest.fail(
-                f"Duplicate base URL found: {base_url}\n"
-                f"  Used by packages: {base_urls[base_url]} and {package}"
-            )
+            if package not in DUPLICATE_EXCLUSION:
+                pytest.fail(
+                    f"Duplicate base URL found: {base_url}\n"
+                    f"  Used by packages: {base_urls[base_url]} and {package}"
+                )
         base_urls[base_url] = package
 
 


### PR DESCRIPTION
Adds links to the 2 currently supported qt python implementations. Adds a versioned link for pyqt5 for consistency. 
In a quick search I could not find docs for pyside2 so these are not added.


Closes #108
